### PR TITLE
refactor: improve variable naming in getOrder method

### DIFF
--- a/src/wallets/multisig-v2/multisig-v2-wrapper.ts
+++ b/src/wallets/multisig-v2/multisig-v2-wrapper.ts
@@ -264,9 +264,9 @@ export class Multisig implements Contract {
   }
 
   getOrder(_: ContractProvider, orderSeqno: bigint): OrderContract {
-    const code_raw = Cell.fromHex(ORDER_CODE);
-    const lib_prep = beginCell().storeUint(2, 8).storeBuffer(code_raw.hash()).endCell();
-    const code = new Cell({ exotic: true, bits: lib_prep.bits, refs: lib_prep.refs });
+    const codeRaw = Cell.fromHex(ORDER_CODE);
+    const libPrep = beginCell().storeUint(2, 8).storeBuffer(codeRaw.hash()).endCell();
+    const code = new Cell({ exotic: true, bits: libPrep.bits, refs: libPrep.refs });
     const data = orderConfigToCell({ multisig: this.address, orderSeqno });
     const init = { code, data };
     const address = contractAddress(0, init);


### PR DESCRIPTION
- Renamed `code_raw` to `codeRaw` and `lib_prep` to `libPrep` for consistency and clarity in the `getOrder` method.